### PR TITLE
Customized the installation of java and environment variables in the recipe

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,11 +1,12 @@
-default['android-sdk']['name']           = 'android-sdk'
-default['android-sdk']['owner']          = 'root'
-default['android-sdk']['group']          = 'root'
-default['android-sdk']['setup_root']     = nil  # ark defaults (/usr/local) is used if this attribute is not defined
+default['android-sdk']['name']                      = 'android-sdk'
+default['android-sdk']['owner']                     = 'root'
+default['android-sdk']['group']                     = 'root'
+default['android-sdk']['setup_root']                = nil  # ark defaults (/usr/local) is used if this attribute is not defined
+default['android-sdk']['set_environment_variables'] = true
 
-default['android-sdk']['version']        = '24.3.3'
-default['android-sdk']['checksum']       = 'a05023aaf149d40a0a848ad49d5c6b43ec730443efb89d1dfa584a132a642bdf'
-default['android-sdk']['download_url']   = "http://dl.google.com/android/android-sdk_r#{node['android-sdk']['version']}-linux.tgz"
+default['android-sdk']['version']                   = '24.3.3'
+default['android-sdk']['checksum']                  = 'a05023aaf149d40a0a848ad49d5c6b43ec730443efb89d1dfa584a132a642bdf'
+default['android-sdk']['download_url']              = "http://dl.google.com/android/android-sdk_r#{node['android-sdk']['version']}-linux.tgz"
 
 #
 # List of Android SDK components to preinstall:
@@ -17,29 +18,29 @@ default['android-sdk']['download_url']   = "http://dl.google.com/android/android
 # Add 'tools' to the list below if you wish to get the latest version,
 # without having to adapt 'version' and 'checksum' attributes of this cookbook.
 # Note that it will require (waste) some extra download effort.
-default['android-sdk']['components']     = %w(platform-tools
-                                              build-tools-22.0.1
-                                              android-22
-                                              sys-img-armeabi-v7a-android-22
-                                              android-21
-                                              sys-img-armeabi-v7a-android-21
-                                              android-20
-                                              sys-img-armeabi-v7a-android-wear-20
-                                              android-19
-                                              sys-img-armeabi-v7a-android-19
-                                              android-18
-                                              sys-img-armeabi-v7a-android-18
-                                              android-17
-                                              sys-img-armeabi-v7a-android-17
-                                              android-16
-                                              sys-img-armeabi-v7a-android-16
-                                              android-15
-                                              sys-img-armeabi-v7a-android-15
-                                              android-10
-                                              extra-android-support
-                                              extra-google-google_play_services
-                                              extra-google-m2repository
-                                              extra-android-m2repository)
+default['android-sdk']['components']                = %w(platform-tools
+                                                        build-tools-22.0.1
+                                                        android-22
+                                                        sys-img-armeabi-v7a-android-22
+                                                        android-21
+                                                        sys-img-armeabi-v7a-android-21
+                                                        android-20
+                                                        sys-img-armeabi-v7a-android-wear-20
+                                                        android-19
+                                                        sys-img-armeabi-v7a-android-19
+                                                        android-18
+                                                        sys-img-armeabi-v7a-android-18
+                                                        android-17
+                                                        sys-img-armeabi-v7a-android-17
+                                                        android-16
+                                                        sys-img-armeabi-v7a-android-16
+                                                        android-15
+                                                        sys-img-armeabi-v7a-android-15
+                                                        android-10
+                                                        extra-android-support
+                                                        extra-google-google_play_services
+                                                        extra-google-m2repository
+                                                        extra-android-m2repository)
 
 default['android-sdk']['license']['white_list']     = %w(android-sdk-license-.+ intel-.+)
 default['android-sdk']['license']['black_list']     = []    # e.g. ['mips-.+', 'android-wear-sdk-license-.+']
@@ -48,5 +49,7 @@ default['android-sdk']['license']['default_answer'] = 'n'   # 'y' or 'n' ('yes' 
 default['android-sdk']['scripts']['path']           = '/usr/local/bin'
 default['android-sdk']['scripts']['owner']          = node['android-sdk']['owner']
 default['android-sdk']['scripts']['group']          = node['android-sdk']['group']
+
+default['android-sdk']['java_from_system']          = false
 
 default['android-sdk']['maven-rescue']              = false

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -23,7 +23,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-include_recipe 'java'
+include_recipe 'java' unless node['android-sdk']['java_from_system']
 
 setup_root       = node['android-sdk']['setup_root'].to_s.empty? ? node['ark']['prefix_home'] : node['android-sdk']['setup_root']
 android_home     = File.join(setup_root, node['android-sdk']['name'])
@@ -55,12 +55,14 @@ end
 #
 ark node['android-sdk']['name'] do
   url node['android-sdk']['download_url']
+  path node['android-sdk']['setup_root']
   checksum node['android-sdk']['checksum']
   version node['android-sdk']['version']
   prefix_root node['android-sdk']['setup_root']
   prefix_home node['android-sdk']['setup_root']
   owner node['android-sdk']['owner']
   group node['android-sdk']['group']
+  action node['android-sdk']['setup_root'].nil? ? :install : :put
 end
 
 #
@@ -94,6 +96,7 @@ template "/etc/profile.d/#{node['android-sdk']['name']}.sh"  do
   variables(
     android_home: android_home
   )
+  only_if { node['android-sdk']['set_environment_variables'] }
 end
 
 package 'expect'


### PR DESCRIPTION
I added attributes `default['android-sdk']['java_from_system']` and `default['android-sdk']['set_environment_variables']` to customize installation of the android-sdk.
Reasons:
- Not everyone wants to install the Java from recipe (https://github.com/agileorbit-cookbooks/java#allow-people-to-not-use-this-cookbook)
- Not everyone wants to create/override environment variables in `/etc/profile.d/

Additionaly, if someone decides to install android-sdk in the custom path then the symlink of the android-sdk directory is not created.
